### PR TITLE
Convert to Mapbox GL JS

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,22 +1,20 @@
-body
-{
-	margin:0;
-	padding:0;
+body {
+    margin: 0;
+    padding: 0;
 }
 
 #contentBox {
     position: absolute;
-    top: 20px;
-    right: 10px;
+    top: 10px;
+    left: 10px;
     margin: 0;
     padding: 0;
     z-index: 100;
 }
 
-#map
-{
-	position:absolute;
-	width:100%;
-	height:100%;
-	z-index: 1;
+#map {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
 }

--- a/index.html
+++ b/index.html
@@ -41,11 +41,13 @@
             container: 'map',
             style: 'mapbox://styles/mapbox/outdoors-v11',
             center: [-89.3842077255249, 43.07471879831505], // starting position [lng, lat]
-            zoom: 14
+            zoom: 14,
+            doubleClickZoom: false
         });
 
-
-        var marker = new mapboxgl.Marker()
+        var marker = new mapboxgl.Marker({
+                color: '#CC0000'
+            })
             .setLngLat([-89.3842077255249, 43.07471879831505])
             .setDraggable(true)
             .addTo(map);
@@ -61,41 +63,17 @@
             document.getElementById('lonText').innerHTML = lonLat.lng.toFixed(5);
         }
 
-        /*
-                L.mapbox.accessToken = "pk.eyJ1IjoiYmxlZWdlIiwiYSI6ImNpazM5eHhxcjAzZ291Z20wcHZhMnludXoifQ.kDBAYabGsDdxtW_C7OH4Zw";
+        // Move Marker On Double Click Of Map
+        map.on('dblclick', function(e) {
+            var lonLat = new mapboxgl.LngLat(e.lngLat.lng, e.lngLat.lat)
+            marker.setLngLat(lonLat)
+            displayLonLat(marker.getLngLat())
+        });
 
-                var map = L.mapbox.map('map', 'mapbox.streets', {
-                    doubleClickZoom: false
-                });
-                map.setView([43.07471879831505, -89.3842077255249], 14);
+        /*
                 map.addControl(L.mapbox.geocoderControl('mapbox.places', {
                     autocomplete: true
                 }));
-
-                var marker = L.marker(new L.LatLng(43.07471879831505, -89.3842077255249), {
-                    icon: L.mapbox.marker.icon({
-                        'marker-color': 'CC0000'
-                    }),
-                    draggable: true
-                });
-                marker.addTo(map);
-                displayLatLon(marker.getLatLng());
-
-                marker.on('dragend', function(event) {
-                    var loc = event.target.getLatLng();
-                    displayLatLon(loc);
-                });
-
-                function displayLatLon(latLon) {
-                    document.getElementById('latText').innerHTML = latLon.lat.toFixed(5);
-                    document.getElementById('lonText').innerHTML = latLon.lng.toFixed(5);
-                }
-
-                // Move Marker On Double Click Of Map
-                map.on('dblclick', function(event) {
-                    marker.setLatLng(event.latlng);
-                    displayLatLon(marker.getLatLng());
-                });
         */
     </script>
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
     <script src='https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.js'></script>
     <link href='https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.css' rel='stylesheet' />
+    <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.5.1/mapbox-gl-geocoder.min.js"></script>
+    <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.5.1/mapbox-gl-geocoder.css" type="text/css" />
 </head>
 
 <body>
@@ -70,11 +72,12 @@
             displayLonLat(marker.getLngLat())
         });
 
-        /*
-                map.addControl(L.mapbox.geocoderControl('mapbox.places', {
-                    autocomplete: true
-                }));
-        */
+        map.addControl(
+            new MapboxGeocoder({
+                accessToken: mapboxgl.accessToken,
+                mapboxgl: mapboxgl
+            })
+        );
     </script>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -1,85 +1,103 @@
 <html>
+
 <head>
-	<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' />
-	<meta charset=utf-8 />
-	<title>Pin Point</title>
-	<link rel="stylesheet" type="text/css" href="css/styles.css">
-	<link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
-	<script src='https://api.mapbox.com/mapbox.js/v2.2.4/mapbox.js'></script>
-	<link href='https://api.mapbox.com/mapbox.js/v2.2.4/mapbox.css' rel='stylesheet' />
+    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' />
+    <meta charset=utf-8 />
+    <title>Pin Point</title>
+    <link rel="stylesheet" type="text/css" href="css/styles.css">
+    <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
+    <script src='https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.js'></script>
+    <link href='https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.css' rel='stylesheet' />
 </head>
 
 <body>
 
-<div id='contentBox' class='note contain fill-light'>
-	<div class="pad2">
-		<table>
-			<thead>
-				<tr>
-					<th>Latitude</th>
-					<th>&nbsp;</th>
-					<th>Longitude</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td id="latText"></td>
-					<td>&nbsp;</td>
-					<td id="lonText"></td>
-				</tr>
-			</tbody>
-		</table>
-	</div>
-</div>
+    <div id='contentBox' class='note contain fill-light'>
+        <div class="pad2">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Latitude</th>
+                        <th>&nbsp;</th>
+                        <th>Longitude</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td id="latText"></td>
+                        <td>&nbsp;</td>
+                        <td id="lonText"></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
 
-<div id="map"></div>
+    <div id="map"></div>
 
-<script type="text/javascript">
-	L.mapbox.accessToken = "pk.eyJ1IjoiYmxlZWdlIiwiYSI6ImNpazM5eHhxcjAzZ291Z20wcHZhMnludXoifQ.kDBAYabGsDdxtW_C7OH4Zw";
+    <script type="text/javascript">
+        mapboxgl.accessToken = "pk.eyJ1IjoiYmxlZWdlIiwiYSI6ImNpazM5eHhxcjAzZ291Z20wcHZhMnludXoifQ.kDBAYabGsDdxtW_C7OH4Zw";
+        var map = new mapboxgl.Map({
+            container: 'map',
+            style: 'mapbox://styles/mapbox/outdoors-v11',
+            center: [-89.3842077255249, 43.07471879831505], // starting position [lng, lat]
+            zoom: 14
+        });
 
-	var map = L.mapbox.map('map', 'mapbox.streets', {
-		doubleClickZoom: false
-	});
-	map.setView([43.07471879831505, -89.3842077255249], 14);
-	map.addControl(L.mapbox.geocoderControl('mapbox.places', {
-        autocomplete: true
-    }));
+        /*
+                L.mapbox.accessToken = "pk.eyJ1IjoiYmxlZWdlIiwiYSI6ImNpazM5eHhxcjAzZ291Z20wcHZhMnludXoifQ.kDBAYabGsDdxtW_C7OH4Zw";
 
-	var marker = L.marker(new L.LatLng(43.07471879831505, -89.3842077255249), {
-		icon: L.mapbox.marker.icon({'marker-color': 'CC0000'}),
-		draggable: true
-	});
-	marker.addTo(map);
-	displayLatLon(marker.getLatLng());
+                var map = L.mapbox.map('map', 'mapbox.streets', {
+                    doubleClickZoom: false
+                });
+                map.setView([43.07471879831505, -89.3842077255249], 14);
+                map.addControl(L.mapbox.geocoderControl('mapbox.places', {
+                    autocomplete: true
+                }));
 
-	marker.on('dragend', function(event) {
-		var loc = event.target.getLatLng();
-		displayLatLon(loc);
-	});
+                var marker = L.marker(new L.LatLng(43.07471879831505, -89.3842077255249), {
+                    icon: L.mapbox.marker.icon({
+                        'marker-color': 'CC0000'
+                    }),
+                    draggable: true
+                });
+                marker.addTo(map);
+                displayLatLon(marker.getLatLng());
 
-	function displayLatLon(latLon) {
-		document.getElementById('latText').innerHTML = latLon.lat.toFixed(5);
-		document.getElementById('lonText').innerHTML = latLon.lng.toFixed(5);
-	}
+                marker.on('dragend', function(event) {
+                    var loc = event.target.getLatLng();
+                    displayLatLon(loc);
+                });
 
-	// Move Marker On Double Click Of Map
-	map.on('dblclick', function(event) {
-		marker.setLatLng(event.latlng);
-		displayLatLon(marker.getLatLng());
-	});
+                function displayLatLon(latLon) {
+                    document.getElementById('latText').innerHTML = latLon.lat.toFixed(5);
+                    document.getElementById('lonText').innerHTML = latLon.lng.toFixed(5);
+                }
 
-</script>
+                // Move Marker On Double Click Of Map
+                map.on('dblclick', function(event) {
+                    marker.setLatLng(event.latlng);
+                    displayLatLon(marker.getLatLng());
+                });
+        */
+    </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <script>
+        (function(i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r;
+            i[r] = i[r] || function() {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date();
+            a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0];
+            a.async = 1;
+            a.src = g;
+            m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-  ga('create', 'UA-36024845-2', 'bleege.github.io');
-  ga('send', 'pageview');
-
-</script>
+        ga('create', 'UA-36024845-2', 'bleege.github.io');
+        ga('send', 'pageview');
+    </script>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -49,12 +49,16 @@
             .setLngLat([-89.3842077255249, 43.07471879831505])
             .setDraggable(true)
             .addTo(map);
-
         displayLonLat(marker.getLngLat());
+        marker.on('dragend', onDragEnd);
 
-        function displayLonLat(latLon) {
-            document.getElementById('latText').innerHTML = latLon.lat.toFixed(5);
-            document.getElementById('lonText').innerHTML = latLon.lng.toFixed(5);
+        function onDragEnd() {
+            displayLonLat(marker.getLngLat())
+        }
+
+        function displayLonLat(lonLat) {
+            document.getElementById('latText').innerHTML = lonLat.lat.toFixed(5);
+            document.getElementById('lonText').innerHTML = lonLat.lng.toFixed(5);
         }
 
         /*

--- a/index.html
+++ b/index.html
@@ -44,6 +44,19 @@
             zoom: 14
         });
 
+
+        var marker = new mapboxgl.Marker()
+            .setLngLat([-89.3842077255249, 43.07471879831505])
+            .setDraggable(true)
+            .addTo(map);
+
+        displayLonLat(marker.getLngLat());
+
+        function displayLonLat(latLon) {
+            document.getElementById('latText').innerHTML = latLon.lat.toFixed(5);
+            document.getElementById('lonText').innerHTML = latLon.lng.toFixed(5);
+        }
+
         /*
                 L.mapbox.accessToken = "pk.eyJ1IjoiYmxlZWdlIiwiYSI6ImNpazM5eHhxcjAzZ291Z20wcHZhMnludXoifQ.kDBAYabGsDdxtW_C7OH4Zw";
 


### PR DESCRIPTION
Mapbox Classic Styles were disabled and stopped being served as of October 2020.  Time to upgrade to GL JS.

https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/